### PR TITLE
prep for 1.0.0 release:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
+- 2.4.1
 notifications:
   email:
     recipients:
@@ -26,8 +27,9 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
+    rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-varnish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.0.0] - 2017-07-02
+### Breaking Changes
+- removed ruby 1.9 support (@majormoses)
+
+### Added
+- ruby 2.3 and 2.4 testing (@majormoses)
+
 ## [0.1.0] - 2017-07-02
 ### Added
 - Added check-varnish-status (@hanynowsky)
@@ -34,7 +41,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-varnish/compare/0.1.0...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-varnish/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/sensu-plugins/sensu-plugins-varnish/compare/0.1.0...1.0.0
 [0.1.0]: https://github.com/sensu-plugins/sensu-plugins-varnish/compare/0.0.5...0.1.0
 [0.0.5]: https://github.com/sensu-plugins/sensu-plugins-varnish/compare/0.0.4...0.0.5
 [0.0.4]: https://github.com/sensu-plugins/sensu-plugins-varnish/compare/0.0.3...0.0.4

--- a/lib/sensu-plugins-varnish/version.rb
+++ b/lib/sensu-plugins-varnish/version.rb
@@ -1,7 +1,7 @@
 module SensuPluginsVarnish
   module Version
-    MAJOR = 0
-    MINOR = 1
+    MAJOR = 1
+    MINOR = 0
     PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')

--- a/sensu-plugins-varnish.gemspec
+++ b/sensu-plugins-varnish.gemspec
@@ -3,11 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
 
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-varnish'
-else
-  require_relative 'lib/sensu-plugins-varnish'
-end
+require_relative 'lib/sensu-plugins-varnish'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu Plugins and contributors']
@@ -28,7 +24,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
 
   s.summary                = 'Sensu plugins for varnish'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
- removed 1.9 ruby support
- added ruby 2.3 && 2.4 testing

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

#9 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
tests were currently failing on ruby 1.9 and took the opportunity to just release a 1.x with breaking changes.
#### Known Compatibility Issues
ruby 1.9 installs will be broken.
