### PR TITLE
Use sudo consistency with full paths to binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
+### Changed
+- Use full path for varnish scripts to allow sudoers files with explicit binaries to work
+
 ### Removed
 - Removed legacy Rake code that prevented rubocop running during Ruby 1.9.3 tests
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@
 
 ## Usage
 
+These checks need to sudo certain varnish scripts to be able to get status and metrics data.
+To ensure sensu can run these commands, add the following to `/etc/sudoers.d/sensu-varnish` or wherever you
+manage your sudo lists;
+
+```
+# Assuming that your varnish scripts are located in /usr/bin;
+sensu ALL=(ALL) NOPASSWD: /usr/bin/varnishadm /usr/bin/varnishstat
+```
+
+
 ## Installation
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)

--- a/bin/check-varnish-status.rb
+++ b/bin/check-varnish-status.rb
@@ -77,7 +77,7 @@ class CheckVarnishStatus < Sensu::Plugin::Check::CLI
   # Main Function
   def run
     # Keep a full reference for the varnish binary so sudo uses a full path
-    varnishadm=`which varnishadm 2>/dev/null`.to_s
+    varnishadm = `which varnishadm 2>/dev/null`.to_s
     unknown 'varnishadm is not installed!' unless varnishadm.include? 'varnish'
     command = `sudo #{varnishadm} -T #{config[:host]}:#{config[:port]} -S #{config[:secret]} -t #{config[:timeout]} #{config[:command]}`
     if config[:command] == 'status'

--- a/bin/check-varnish-status.rb
+++ b/bin/check-varnish-status.rb
@@ -76,8 +76,10 @@ class CheckVarnishStatus < Sensu::Plugin::Check::CLI
 
   # Main Function
   def run
-    unknown 'varnishadm is not installed!' unless `which varnishadm 2>/dev/null`.to_s.include? 'varnish'
-    command = `sudo varnishadm -T #{config[:host]}:#{config[:port]} -S #{config[:secret]} -t #{config[:timeout]} #{config[:command]}`
+    # Keep a full reference for the varnish binary so sudo uses a full path
+    varnishadm=`which varnishadm 2>/dev/null`.to_s
+    unknown 'varnishadm is not installed!' unless varnishadm.include? 'varnish'
+    command = `sudo #{varnishadm} -T #{config[:host]}:#{config[:port]} -S #{config[:secret]} -t #{config[:timeout]} #{config[:command]}`
     if config[:command] == 'status'
       if command.include? 'state running'
         ok 'Up & Running'

--- a/bin/metrics-varnish.rb
+++ b/bin/metrics-varnish.rb
@@ -61,6 +61,10 @@ class VarnishMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def run
+    # Keep a full reference for the varnish binary so sudo uses a full path
+    varnishstat_command=`which varnishstat 2>/dev/null`.to_s
+    unknown 'varnishstat is not installed!' unless varnishstat_command.include? 'varnish'
+
     begin
       fieldargs = ''
       if config[:fields]
@@ -74,10 +78,11 @@ class VarnishMetrics < Sensu::Plugin::Metric::CLI::Graphite
       end
 
       varnishstat = if config[:varnish_name]
-                      `varnishstat -x -n #{config[:varnish_name]} #{fieldargs}`
+                      `sudo #{varnishstat_command} -x -n #{config[:varnish_name]} #{fieldargs}`
                     else
-                      `varnishstat -x #{fieldargs}`
+                      `sudo #{varnishstat_command} -x #{fieldargs}`
                     end
+
       stats = Crack::XML.parse(varnishstat)
       if stats['varnishstat']['stat']
         stats['varnishstat']['stat'].each do |stat|

--- a/bin/metrics-varnish.rb
+++ b/bin/metrics-varnish.rb
@@ -62,7 +62,7 @@ class VarnishMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     # Keep a full reference for the varnish binary so sudo uses a full path
-    varnishstat_command=`which varnishstat 2>/dev/null`.to_s
+    varnishstat_command = `which varnishstat 2>/dev/null`.to_s
     unknown 'varnishstat is not installed!' unless varnishstat_command.include? 'varnish'
 
     begin


### PR DESCRIPTION

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- ~[ ] Binstubs are created if needed~

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- ~[ ] Tests~

- ~[ ] Add the plugin to the README~

- ~[ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)~

#### Purpose

Sudoers files dont let you include binaries without setting the full path so ensure that we always use full paths when invoking binaries from ruby

#### Known Compatibility Issues

None