### PR TITLE
BugFix - Which is newline terminated causing execution to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 
 ### Fixed
- - `which` may return multiple options, and always ends with a newline - Split and take the first option
-
+ - `which` returns a newline terminated string in all cases - strip it before trying to run the command otherwise
+   the generated command will be split over two lines and fail
+   
 ## [1.1.0] - 2017-08-01
 ### Changed
 - Use full path for varnish scripts to allow sudoers files with explicit binaries to work (@warmfusion)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Fixed
+ - `which` may return multiple options, and always ends with a newline - Split and take the first option
+
 ## [1.1.0] - 2017-08-01
 ### Changed
 - Use full path for varnish scripts to allow sudoers files with explicit binaries to work (@warmfusion)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ manage your sudo lists;
 
 ```
 # Assuming that your varnish scripts are located in /usr/bin;
-sensu ALL=(ALL) NOPASSWD: /usr/bin/varnishadm /usr/bin/varnishstat
+sensu ALL=(ALL) NOPASSWD: /usr/bin/varnishadm, /usr/bin/varnishstat
 ```
 
 

--- a/bin/check-varnish-status.rb
+++ b/bin/check-varnish-status.rb
@@ -77,7 +77,7 @@ class CheckVarnishStatus < Sensu::Plugin::Check::CLI
   # Main Function
   def run
     # Keep a full reference for the varnish binary so sudo uses a full path
-    varnishadm = `which varnishadm 2>/dev/null`.split("\n").first
+    varnishadm = `which varnishadm 2>/dev/null`.strip
     unknown 'varnishadm is not installed!' unless varnishadm.include? 'varnish'
     command = `sudo #{varnishadm} -T #{config[:host]}:#{config[:port]} -S #{config[:secret]} -t #{config[:timeout]} #{config[:command]}`
     if config[:command] == 'status'

--- a/bin/check-varnish-status.rb
+++ b/bin/check-varnish-status.rb
@@ -77,7 +77,7 @@ class CheckVarnishStatus < Sensu::Plugin::Check::CLI
   # Main Function
   def run
     # Keep a full reference for the varnish binary so sudo uses a full path
-    varnishadm = `which varnishadm 2>/dev/null`.to_s
+    varnishadm = `which varnishadm 2>/dev/null`.split("\n").first
     unknown 'varnishadm is not installed!' unless varnishadm.include? 'varnish'
     command = `sudo #{varnishadm} -T #{config[:host]}:#{config[:port]} -S #{config[:secret]} -t #{config[:timeout]} #{config[:command]}`
     if config[:command] == 'status'

--- a/bin/metrics-varnish.rb
+++ b/bin/metrics-varnish.rb
@@ -62,7 +62,7 @@ class VarnishMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     # Keep a full reference for the varnish binary so sudo uses a full path
-    varnishstat_command = `which varnishstat 2>/dev/null`.split("\n").first
+    varnishstat_command = `which varnishstat 2>/dev/null`.strip
     unknown 'varnishstat is not installed!' unless varnishstat_command.include? 'varnish'
 
     begin

--- a/bin/metrics-varnish.rb
+++ b/bin/metrics-varnish.rb
@@ -62,7 +62,7 @@ class VarnishMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     # Keep a full reference for the varnish binary so sudo uses a full path
-    varnishstat_command = `which varnishstat 2>/dev/null`.to_s
+    varnishstat_command = `which varnishstat 2>/dev/null`.split("\n").first
     unknown 'varnishstat is not installed!' unless varnishstat_command.include? 'varnish'
 
     begin


### PR DESCRIPTION
Bugfix - Found that which returns newline's on strings which doesn't actually work as expected.

Don't know how this snuck through my testing on the host - we ensure that the newline is removed with a simple strip.

`Which` should never return multiple responses.
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

~- [ ] Binstubs are created if needed~

- [ ] RuboCop passes

- [ ] Existing tests pass
