### PR TITLE
Backend health command changed on new Varnish versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.1.2] - 2017-08-29
+### Fixed
+ - updated backend status check to include new Varnish command `backend.list` (@shaun-rutherford)
+
 ## [1.1.1] - 2017-08-18
 ### Fixed
  - `which` returns a newline terminated string in all cases - strip it before trying to run the command otherwise the generated command will be split over two lines and fail (@warmfusion)

--- a/bin/check-varnish-status.rb
+++ b/bin/check-varnish-status.rb
@@ -88,7 +88,7 @@ class CheckVarnishStatus < Sensu::Plugin::Check::CLI
       end
     end
 
-    if config[:command] == 'debug.health' or config[:command] == 'backend.list'
+    if config[:command] == 'debug.health' || config[:command] == 'backend.list'
       if command.downcase.include? 'sick'
         critical 'Sick backends detected'
       else

--- a/bin/check-varnish-status.rb
+++ b/bin/check-varnish-status.rb
@@ -88,7 +88,7 @@ class CheckVarnishStatus < Sensu::Plugin::Check::CLI
       end
     end
 
-    if config[:command] == 'debug.health'
+    if config[:command] == 'debug.health' or config[:command] == 'backend.list'
       if command.downcase.include? 'sick'
         critical 'Sick backends detected'
       else


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [ x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ x] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
New Versions of Varnish changed the debug.health command to backend.list, added code to check for either.
#### Known Compatibility Issues
